### PR TITLE
Fix NMG stat preset

### DIFF
--- a/BossRush/FightStorage.cs
+++ b/BossRush/FightStorage.cs
@@ -120,7 +120,7 @@ namespace BossRush
         public static Dictionary<int, int[]> nmgStatPreset = new Dictionary<int, int[]>() //index = fight where you first have stats (starts at 0 cause list)
         {
             {4, new int[] {2,0,0,0} },
-            {8, new int[] {3,0,0,0} },
+            {7, new int[] {3,0,0,0} },
             {12, new int[] {4,0,0,0} },
             {21, new int[] {5,1,0,0} },
             {23, new int[] {5,2,0,0} }


### PR DESCRIPTION
The first fight in mushroom dungeon in the NMG preset should already have 3 strength. Currently, only the second fight onwards have the correct stat.